### PR TITLE
F42: branched from Rawhide

### DIFF
--- a/fedora-iot-42.yaml
+++ b/fedora-iot-42.yaml
@@ -1,0 +1,4 @@
+releasever: 42
+repos:
+  - fedora-devel
+include: fedora-iot-bootc.yaml


### PR DESCRIPTION
Fedora 42 has branched from Rawhide, add a treefile for the development release. 