### PR TITLE
Rename tier-x to minimal-plus to match upstream changes

### DIFF
--- a/fedora-iot-bootc.yaml
+++ b/fedora-iot-bootc.yaml
@@ -6,6 +6,6 @@ metadata:
   summary: Fedora IoT bootc image
 
 include:
-  - base-images/tier-x/manifest.yaml
-  - base-images/tier-x/kernel.yaml
+  - base-images/minimal-plus/manifest.yaml
+  - base-images/fedora-includes/generic.yaml
   - iot-packages.yaml


### PR DESCRIPTION
Tier-x has been renamed to `minimal-plus` and a new yaml for Fedora specific packages added. 