### PR TITLE
Dependabot reviewers configuration option replaced by code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/* @fedora-iot/iot-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,3 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "Submodule Update: "
-    reviewers:
-      - "fedora-iot/iot-team"


### PR DESCRIPTION
Dependabot reviewers configuration option replaced by code owners

See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/