### PR TITLE
Branch Fedora IoT 45: add versioned treefile

### DIFF
--- a/fedora-iot-45.yaml
+++ b/fedora-iot-45.yaml
@@ -1,0 +1,4 @@
+releasever: 45
+repos:
+  - fedora-devel
+include: fedora-iot-bootc.yaml


### PR DESCRIPTION
Add `fedora-iot-45.yaml` treefile for the F45 branched release, using `fedora-devel` repo.

The `fedora-iot-rawhide.yaml` file is unchanged — it continues serving whatever version is rawhide next.